### PR TITLE
Fix link to Trace Collector repo

### DIFF
--- a/supported_apps.md
+++ b/supported_apps.md
@@ -7,6 +7,6 @@
 - [nRF Connect Programmer](https://github.com/NordicSemiconductor/pc-nrfconnect-programmer)
 - [nRF Connect Getting Started Assistant](https://github.com/NordicSemiconductor/pc-nrfconnect-gettingstarted)
 - [nRF Connect LTE Link Monitor](https://github.com/NordicSemiconductor/pc-nrfconnect-linkmonitor)
-- [nRF Connect Trace Collector](https://github.com/NordicPlayground/pc-nrfconnect-tracecollector)
+- [nRF Connect Trace Collector](https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector)
 - [nRF Connect Power Profiler](https://github.com/NordicSemiconductor/pc-nrfconnect-ppk)
 - [nRF Connect RSSI Viewer](https://github.com/NordicSemiconductor/pc-nrfconnect-rssi)


### PR DESCRIPTION
Because it was transferred to the main GitHub org.