### PR TITLE
Reference Contributing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ matter”: Two lines with three dashes like this at the beginning:
 Sometimes Jekyll does not process the markdown files correctly without that and
 [the GitHub Pages documentation also says they are required](https://help.github.com/en/articles/configuring-jekyll#front-matter-is-required),
 so just include them, like in any other documentation file in this project.
+
+## Contributing
+
+See the
+[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+for details.

--- a/contributing.md
+++ b/contributing.md
@@ -3,9 +3,11 @@
 
 # Contributing
 
-Feel free to file code related issues on GitHub Issues and/or submit a pull
-request. In order to accept your pull request, we need you to sign our
-Contributor License Agreement (CLA). You will see instructions for doing this
-after having submitted your first pull request. You only need to sign the CLA
-once, so if you have already done it for another project in the
-NordicSemiconductor organization, you are good to go.
+Feel free to file code and documentation related issues on GitHub Issues and/or
+submit a pull request.
+
+In order to accept your pull request, we need you to sign our Contributor
+License Agreement (CLA). You will see instructions for doing this after having
+submitted your first pull request. You only need to sign the CLA once, so if you
+have already done it for another project in the NordicSemiconductor
+organization, you are good to go.


### PR DESCRIPTION
As it is the standard in all our projects.

Also slightly enhance contributing.md: Mention docs and split off the paragraph on the CLA.