### PR TITLE
Describe installing dev tools for Electron

### DIFF
--- a/app_development.md
+++ b/app_development.md
@@ -38,7 +38,8 @@ When you edit the source of the app and it is recompiled (probably by keeping
 in the running app window will make it reload.
 
 Chrome Developer Tools can be opened by pressing `Ctrl+Alt+I` (Windows/Linux) or
-`Cmd+Option+I` (macOS).
+`Cmd+Option+I` (macOS). We recommend that you
+[install the DevTools for React and Redux](./core_development#installing-the-electron-dev-tools).
 
 ## Testing
 

--- a/core_development.md
+++ b/core_development.md
@@ -85,3 +85,20 @@ Relevant scripts for different testing needs:
   network access
 - `npm run test-e2e-online`: Run only end-to-end tests that require network
   access
+
+## Installing the Electron dev tools
+
+During development the
+[React DevTools](https://github.com/facebook/react/tree/master/packages/react-devtools)
+and the [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension)
+are really handy. The easiest way to install them is to run
+
+    npm run install-devtools
+
+when you have the source of the core checked out as described above. You only
+need to run this command once, the tools will stay installed in subsequent runs
+of Electron.
+
+If you want to remove all dev tools later run
+
+    npm run remove-devtools


### PR DESCRIPTION
This accompanies NordicSemiconductor/pc-nrfconnect-core#381, since it describes how the DevTool installation added there can be triggered.