### PR TITLE
Correct reference to project core/launcher

### DIFF
--- a/adding_navigation_menu_items.md
+++ b/adding_navigation_menu_items.md
@@ -28,7 +28,7 @@ here, but a React class component could also have been used.
 
 Our functional component receives the `props` that are passed to `NavMenu`. See
 the
-[NavMenu source code](https://github.com/NordicSemiconductor/pc-nrfconnect-core/blob/master/lib/components/NavMenu.jsx)
+[NavMenu source code](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/master/src/legacy/components/NavMenu.jsx)
 to see which props the component expects. We override the `menuItems` prop to
 pass in our own menu items, but keep the rest of the props by using the
 [spread syntax](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Spread_operator).
@@ -39,7 +39,7 @@ We have now added some items, but so far nothing will happen in the UI when
 selecting them. By default, when clicking a menu item, a
 `NAV_MENU_ITEM_SELECTED` action is dispatched with the selected item ID. This
 action is handled by the
-[navMenuReducer](https://github.com/NordicSemiconductor/pc-nrfconnect-core/blob/master/lib/windows/app/reducers/navMenuReducer.js),
+[navMenuReducer](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/master/src/legacy/app/reducers/navMenuReducer.js),
 which sets `state.core.navMenu.selectedItemId`.
 
 Let us say you want to render different content in the `MainView` based on the

--- a/api_reference.md
+++ b/api_reference.md
@@ -189,7 +189,7 @@ for a complete example.
       </td>
       <td>
         <p>A custom <a href="http://redux.js.org/docs/advanced/Middleware.html">Redux middleware</a> that can intercept any action. The middleware is invoked after an action has been dispatched, but before it reaches the reducers.</p>
-        <p>This is useful e.g. when the app wants to perform some asynchronous operation when an action is dispatched by core. Refer to the <a href="https://github.com/NordicSemiconductor/pc-nrfconnect-core/tree/master/lib/windows/app/actions">core actions</a> to see which actions may be intercepted. See <a href="#intercepting-actions-with-middleware">examples</a>.</p>
+        <p>This is useful e.g. when the app wants to perform some asynchronous operation when an action is dispatched by core. Refer to the <a href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/tree/master/src/legacy/app/actions">core actions</a> to see which actions may be intercepted. See <a href="#intercepting-actions-with-middleware">examples</a>.</p>
       </td>
     </tr>
     <tr>
@@ -325,7 +325,7 @@ documentation to see how this is done.
 ### Passing information from state to components
 
 The nRF Connect core keeps its state under `state.core`. Refer to the
-[coreReducer](https://github.com/NordicSemiconductor/pc-nrfconnect-core/blob/master/lib/windows/app/reducers/coreReducer.js)
+[coreReducer](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/master/src/legacy/app/reducers/coreReducer.js)
 to see what information may be found there. The app can maintain its own state
 under `state.app` by implementing the `reduceApp` method.
 
@@ -361,7 +361,7 @@ By implementing a
 intercept or act upon actions before they are received by the reducers. This is
 useful for changing or expanding on the default nRF Connect behavior. Refer to
 the
-[core actions](https://github.com/NordicSemiconductor/pc-nrfconnect-core/tree/master/lib/windows/app/actions)
+[core actions](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/tree/master/src/legacy/app/actions)
 to see the list of actions that may pass through the middleware.
 
 A common scenario is that the app should open serial port when a port has been

--- a/core_development.md
+++ b/core_development.md
@@ -4,7 +4,7 @@
 # How to do development of the core of nRF Connect for Desktop
 
 Developing
-[the core of nRF Connect for Desktop](https://github.com/NordicSemiconductor/pc-nrfconnect-core)
+[the core of nRF Connect for Desktop](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher)
 is a bit different than [developing an app](./app_development) for it.
 
 As you have read in the
@@ -51,7 +51,7 @@ which describes requirements for compilation.
 ## Running from source
 
 Fetch the source from
-[https://github.com/NordicSemiconductor/pc-nrfconnect-core](https://github.com/NordicSemiconductor/pc-nrfconnect-core)
+[https://github.com/NordicSemiconductor/pc-nrfconnect-launcher](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher)
 and like on most Node.js projects, you need to install the dependencies once at
 the beginning with `npm install` and only need to repeat that later if the
 dependencies change.

--- a/getting_started.md
+++ b/getting_started.md
@@ -28,7 +28,7 @@ You should have a basic setup and little familiarity with these:
 If you only want to develop (existing or new) apps, it is sufficient to have nRF
 Connect for Desktop installed as a binary. If you do not have it installed
 already, just follow the
-[instructions on how to install nRF Connect for Desktop](https://github.com/NordicSemiconductor/pc-nrfconnect-core#using-nrf-connect-for-desktop).
+[instructions on how to install nRF Connect for Desktop](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher#using-nrf-connect-for-desktop).
 
 Also create the `~/.nrfconnect-apps/local` directory if it does not already
 exist:
@@ -44,7 +44,7 @@ The two main blocks are the core and the apps:
 ### The core
 
 The core resides in the project
-[`pc-nrfconnect-core`](https://github.com/NordicSemiconductor/pc-nrfconnect-core)
+[`pc-nrfconnect-launcher`](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher)
 and provides multiple things:
 
 - The launcher from which the apps are installed and launched

--- a/opening_selected_device.md
+++ b/opening_selected_device.md
@@ -63,14 +63,14 @@ action
 Apps can listen to actions and implement custom behavior when a certain action
 is dispatched. Now we know which actions to listen to, plus the information that
 can be pulled out from the actions. To see all actions that are available, see
-[lib/windows/app/actions](https://github.com/NordicSemiconductor/pc-nrfconnect-core/tree/master/lib/windows/app/actions).
+[src/legacy/app/actions](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/tree/master/src/legacy/app/actions).
 
 ## Acting upon actions with middleware
 
 By implementing
 [middleware](./api_reference#intercepting-actions-with-middleware), apps can
 intercept or act upon actions before they are received by the
-[reducers](https://github.com/NordicSemiconductor/pc-nrfconnect-core/tree/master/lib/windows/app/reducers).
+[reducers](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/tree/master/src/legacy/app/reducers).
 Middleware may seem a bit odd at first, and you can read more about it in the
 [Redux documentation](http://redux.js.org/docs/advanced/Middleware.html).
 However, you do not need to know all the details to use it. A middleware


### PR DESCRIPTION
This is part of [NCP-2704](https://projecttools.nordicsemi.no/jira/browse/NCP-2704).

The project `pc-nrfconnect-core` was renamed to `pc-nrfconnect-launcher`. This corrects references to the old name (links are redirected but it might still be confusing to keep on using the old name).