### PR TITLE
Describe new architecture

### DIFF
--- a/adding_navigation_menu_items.md
+++ b/adding_navigation_menu_items.md
@@ -1,6 +1,10 @@
 ---
 ---
 
+<div class="highlight">
+  <h2 class="err">Caveat: This page still describes the old architecture.</h2>
+</div>
+
 # Adding navigation menu items
 
 The navigation menu is rendered by the `NavMenu` component. The component

--- a/api_reference.md
+++ b/api_reference.md
@@ -1,6 +1,10 @@
 ---
 ---
 
+<div class="highlight">
+  <h2 class="err">Caveat: This page still describes the old architecture.</h2>
+</div>
+
 # API reference
 
 The API for nRF Connect apps is inspired by the extension API used by the

--- a/core_development.md
+++ b/core_development.md
@@ -76,7 +76,55 @@ have a binary installation of nRF Connect for Desktop or
 [develop local apps](./app_development), the same apps will show up in this
 instance too.
 
-### Testing
+## Developing common code in [pc-nrfconnect-shared](https://github.com/NordicSemiconductor/pc-nrfconnect-shared)
+
+When you are developing common code in `pc-nrfconnect-shared` and you want to
+check the changes quickly in the launcher or an app the steps above are not
+sufficient, because by default the launcher will include a released version of
+`pc-nrfconnect-shared` from GitHub, not you local one. But with some additional
+effort you can achieve this by leveraging
+[`npm-link`](https://docs.npmjs.com/cli/link):
+
+1. Have both, `pc-nrfconnect-launcher` and `pc-nrfconnect-shared` checked out
+   into directories next to each other.
+2. In the directory `pc-nrfconnect-launcher` run
+```
+npm install; npm link ../pc-nrfconnect-shared
+```
+3. In the directory `pc-nrfconnect-shared` run
+```
+npm ci --prod
+```
+
+With this setup, you can make changes in `pc-nrfconnect-shared`, then recompile
+`pc-nrfconnect-launcher` (`pc-nrfconnect-shared` does not need to be compiled),
+and immediately see the effects of the changes in `pc-nrfconnect-shared`.
+Usually the best setup is again to use `npm run dev` in
+`pc-nrfconnect-launcher`, as described above in
+[“Running the launcher from source”](#running-the-launcher-from-source).
+
+If you forget to run `npm ci --prod` in `pc-nrfconnect-shared`, you may get
+errors because of conflicting package versions, especially of `react` and
+`react-redux`.
+
+### Caveat:
+
+If you later run `npm install` in the directory `pc-nrfconnect-launcher` (e.g.
+because you install additional packages), the link to `pc-nrfconnect-shared`
+often gets lost. In that case you usually have to repeat running
+`link ../pc-nrfconnect-shared` in the directory `pc-nrfconnect-launcher` and
+then `npm ci --prod` in the directory `pc-nrfconnect-shared`.
+
+If you later run `npm install` in the directory `pc-nrfconnect-shared` (e.g.
+because you install additional packages there), you may need to repeat running
+`npm ci --prod` in that folder.
+
+Because `npm ci --prod` does not install the development dependencies, you
+cannot run the tests successfully in `pc-nrfconnect-shared` at that moment.
+Before you want to run the tests again, execute `npm ci` and you will also have
+the development dependencies installed again.
+
+## Testing
 
 Relevant scripts for different testing needs:
 

--- a/core_development.md
+++ b/core_development.md
@@ -3,13 +3,16 @@
 
 # How to do development of the core of nRF Connect for Desktop
 
-Developing
-[the core of nRF Connect for Desktop](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher)
-is a bit different than [developing an app](./app_development) for it.
+Developing the core of nRF Connect for Desktop is a bit different than
+[developing an app](./app_development) for it.
 
-As you have read in the
-[architecture summary about the core](./getting_started#the-core), the core
-project is responsible for multiple things. So there could be several
+As you have read in the [architecture summary](./getting_started#the-core) the
+core is split up over two projects:
+[`pc-nrfconnect-launcher`](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher)
+and
+[`pc-nrfconnect-shared`](https://github.com/NordicSemiconductor/pc-nrfconnect-shared).
+
+These projects are responsible for multiple things. So there could be several
 motivations for working on it: Most probably you want to change the launcher or
 code that is common for the apps.
 
@@ -48,7 +51,7 @@ not exist for your platform/Node.js version, then refer to the
 [pc-ble-driver-js README](https://github.com/NordicSemiconductor/pc-ble-driver-js)
 which describes requirements for compilation.
 
-## Running from source
+## Running the launcher from source
 
 Fetch the source from
 [https://github.com/NordicSemiconductor/pc-nrfconnect-launcher](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher)
@@ -80,11 +83,7 @@ Relevant scripts for different testing needs:
 - `npm run lint`: Lint the source
 - `npm test`: Run the unit tests once
 - `npm run test-watch`: Run unit tests and watch for changes
-- `npm run test-e2e`: Run all end-to-end tests
-- `npm run test-e2e-offline`: Run only end-to-end tests that do not require
-  network access
-- `npm run test-e2e-online`: Run only end-to-end tests that require network
-  access
+- `npm run test-e2e`: The launcher additionally included end-to-end tests
 
 ## Installing the Electron dev tools
 

--- a/core_development.md
+++ b/core_development.md
@@ -81,7 +81,7 @@ instance too.
 When you are developing common code in `pc-nrfconnect-shared` and you want to
 check the changes quickly in the launcher or an app the steps above are not
 sufficient, because by default the launcher will include a released version of
-`pc-nrfconnect-shared` from GitHub, not you local one. But with some additional
+`pc-nrfconnect-shared` from GitHub, not your local one. But with some additional
 effort you can achieve this by leveraging
 [`npm-link`](https://docs.npmjs.com/cli/link):
 
@@ -112,7 +112,7 @@ errors because of conflicting package versions, especially of `react` and
 If you later run `npm install` in the directory `pc-nrfconnect-launcher` (e.g.
 because you install additional packages), the link to `pc-nrfconnect-shared`
 often gets lost. In that case you usually have to repeat running
-`link ../pc-nrfconnect-shared` in the directory `pc-nrfconnect-launcher` and
+`npm link ../pc-nrfconnect-shared` in the directory `pc-nrfconnect-launcher` and
 then `npm ci --prod` in the directory `pc-nrfconnect-shared`.
 
 If you later run `npm install` in the directory `pc-nrfconnect-shared` (e.g.

--- a/getting_started.md
+++ b/getting_started.md
@@ -39,13 +39,23 @@ exist:
 ## Architecture of nRF Connect for Desktop
 
 Before starting, you should know the basic structure of nRF Connect for Desktop.
-The two main blocks are the core and the apps:
+
+It is currently a bit in flux, because we are transitioning to a slightly
+different architecture. The overall concept stays the same, but sometimes there
+are differences and then we will explain the difference between the old and the
+new architecture. When developing new apps, you should stick to the new
+architecture, but when working on existing apps or the core, you might need to
+be aware of the old architecture.
+
+Which brings us right to the two main blocks the core and the apps:
 
 ### The core
 
-The core resides in the project
+The core resides in the two projects
 [`pc-nrfconnect-launcher`](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher)
-and provides multiple things:
+and
+[`pc-nrfconnect-shared`](https://github.com/NordicSemiconductor/pc-nrfconnect-shared).
+It provides multiple things:
 
 - The launcher from which the apps are installed and launched
 - The [Electron shell](https://electronjs.org) in which the launcher and the
@@ -53,16 +63,30 @@ and provides multiple things:
 - The common code for all apps: UI elements and code to give lower level access
   hardware
 
-A bit unusual: The common code is not only provided during development, the
-libraries are also provided during runtime, so that the individual apps do not
-have to provide them themselves.
+Where the last part, the common code, resides changes with the new architecture:
+Now it is found in project `pc-nrfconnect-shared` (since release
+[v4.8.0](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v4.8.0)
+of that project) but previously it was also included in
+``pc-nrfconnect-launcher`, where now only legacy variants remain for apps that
+have not been converted to the new architecture.
 
-Providing the common libraries through the core at runtime has two advantages
-for the apps: The apps can be a lot smaller and they are usually platform
-independent, as the only platform specific parts are in the core.
+A bit unusual: The common code is not only provided during development and then
+compiled into the apps. Instead the launcher also provides these libraries
+during runtime, so that the individual apps do not have to include the shared
+code themselves.
+
+Providing the common libraries through the launcher at runtime has two
+advantages for the apps: The apps can be a lot smaller and they are usually
+platform independent, as the only platform specific parts are in the core.
 
 Conversely, this means that the core is platform dependent and a
 platform-specific variant must be downloaded or compiled.
+
+Besides common code `pc-nrfconnect-shared` also provides common package
+dependencies, scripts and configurations for all official applications and the
+core. E.g. it includes configurations for [webpack](https://webpack.js.org),
+[ESLint](https://eslint.org) and [Jest](https://jestjs.io) as well as scripts to
+run them.
 
 ### The apps
 
@@ -90,11 +114,6 @@ for Desktop:
   - [`pc-ble-driver-js`](https://github.com/NordicSemiconductor/pc-ble-driver-js)
     to access
     [the `pc-ble-driver` library](https://github.com/NordicSemiconductor/pc-ble-driver).
-- [`pc-nrfconnect-devdep`](https://github.com/NordicSemiconductor/pc-nrfconnect-devdep)
-  provides common package dependencies, scripts and configurations for all
-  official applications and the core. E.g. it includes configurations for
-  [webpack](https://webpack.js.org), [ESLint](https://eslint.org) and
-  [Jest](https://jestjs.io) as well as scripts to run them.
 - [`pc-nrfconnect-boilerplate`](https://github.com/NordicSemiconductor/pc-nrfconnect-boilerplate)
   is a very minimal app, which is not useful on it's own, but may be used as a
   template to start new apps.

--- a/getting_started.md
+++ b/getting_started.md
@@ -98,6 +98,8 @@ for Desktop:
 - [`pc-nrfconnect-boilerplate`](https://github.com/NordicSemiconductor/pc-nrfconnect-boilerplate)
   is a very minimal app, which is not useful on it's own, but may be used as a
   template to start new apps.
+- [`pc-nrfconnect-docs`](https://github.com/NordicSemiconductor/pc-nrfconnect-docs)
+  contains these pages to describe how to develop nRF Connect for Desktop.
 
 ## Next steps
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -67,7 +67,7 @@ Where the last part, the common code, resides changes with the new architecture:
 Now it is found in project `pc-nrfconnect-shared` (since release
 [v4.8.0](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v4.8.0)
 of that project) but previously it was also included in
-``pc-nrfconnect-launcher`, where now only legacy variants remain for apps that
+`pc-nrfconnect-launcher`, where now only legacy variants remain for apps that
 have not been converted to the new architecture.
 
 A bit unusual: The common code is not only provided during development and then

--- a/opening_selected_device.md
+++ b/opening_selected_device.md
@@ -1,6 +1,10 @@
 ---
 ---
 
+<div class="highlight">
+  <h2 class="err">Caveat: This page still describes the old architecture.</h2>
+</div>
+
 # Opening selected device
 
 ## Introduction

--- a/programming_selected_device.md
+++ b/programming_selected_device.md
@@ -1,6 +1,10 @@
 ---
 ---
 
+<div class="highlight">
+  <h2 class="err">Caveat: This page still describes the old architecture.</h2>
+</div>
+
 # Programming selected device
 
 ## Introduction


### PR DESCRIPTION
This implements [NCP-2832](https://projecttools.nordicsemi.no/jira/browse/NCP-2832).

Add descriptions about the new architecture and also about how to develop the common code in `pc-nrfconnect-shared`. Some pages are just completely only about the old architecture, so for now I just added a warning.