### PR TITLE
Fix GitHub Pages build

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -5,7 +5,7 @@ $nordic-blue: #00a9ce;
 
 $text-blue: $nordic-blue;
 
-@import '{{ site.theme }}';
+@import 'jekyll-theme-primer';
 
 body {
   padding: 50px;


### PR DESCRIPTION
The error message, e.g. in an [example run][1]:

> Your SCSS file assets/css/style.scss has an error on line 5: File to
> import not found or unreadable: primer.

According to [an issue on pages-themes][2], this is the way to fix it
for now.

[1]: https://github.com/NordicSemiconductor/pc-nrfconnect-docs/runs/3171555315
[2]: https://github.com/pages-themes/cayman/issues/130